### PR TITLE
INTMDB-595: Update Quickstart template region AP_EAST_2 to AP_EAST_1

### DIFF
--- a/templates/activate-mongodb-atlas-resources.template.yaml
+++ b/templates/activate-mongodb-atlas-resources.template.yaml
@@ -21,7 +21,7 @@ Parameters:
     - "us-west-2"
     - "sa-east-1"
     - "ap-south-1"
-    - "ap-east-2"
+    - "ap-east-1"
     - "ap-southeast-1"
     - "ap-southeast-2"
     - "ap-southeast-3"

--- a/templates/mongodb-atlas-main.template.yaml
+++ b/templates/mongodb-atlas-main.template.yaml
@@ -140,7 +140,6 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
-      - "4.2"
       - "4.4"
       - "5.0"
       - "6.0"

--- a/templates/mongodb-atlas-main.template.yaml
+++ b/templates/mongodb-atlas-main.template.yaml
@@ -120,7 +120,7 @@ Parameters:
       - "US_WEST_2"
       - "SA_EAST_1"
       - "AP_SOUTH_1"
-      - "AP_EAST_2"
+      - "AP_EAST_1"
       - "AP_SOUTHEAST_1"
       - "AP_SOUTHEAST_2"
       - "AP_SOUTHEAST_3"

--- a/templates/mongodb-atlas-main.template.yaml
+++ b/templates/mongodb-atlas-main.template.yaml
@@ -140,6 +140,7 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
+      - "4.2"
       - "4.4"
       - "5.0"
       - "6.0"

--- a/templates/mongodb-atlas-peering-existingvpc.template.yaml
+++ b/templates/mongodb-atlas-peering-existingvpc.template.yaml
@@ -128,7 +128,7 @@ Parameters:
       - "US_WEST_2"
       - "SA_EAST_1"
       - "AP_SOUTH_1"
-      - "AP_EAST_2"
+      - "AP_EAST_1"
       - "AP_SOUTHEAST_1"
       - "AP_SOUTHEAST_2"
       - "AP_SOUTHEAST_3"

--- a/templates/mongodb-atlas-peering-existingvpc.template.yaml
+++ b/templates/mongodb-atlas-peering-existingvpc.template.yaml
@@ -148,7 +148,6 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
-      - "4.2"
       - "4.4"
       - "5.0"
       - "6.0"

--- a/templates/mongodb-atlas-peering-existingvpc.template.yaml
+++ b/templates/mongodb-atlas-peering-existingvpc.template.yaml
@@ -148,6 +148,7 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
+      - "4.2"
       - "4.4"
       - "5.0"
       - "6.0"

--- a/templates/mongodb-atlas-peering-newvpc.template.yaml
+++ b/templates/mongodb-atlas-peering-newvpc.template.yaml
@@ -197,6 +197,7 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
+      - "4.2"
       - "4.4"
       - "5.0"
       - "6.0"

--- a/templates/mongodb-atlas-peering-newvpc.template.yaml
+++ b/templates/mongodb-atlas-peering-newvpc.template.yaml
@@ -197,7 +197,6 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
-      - "4.2"
       - "4.4"
       - "5.0"
       - "6.0"

--- a/templates/mongodb-atlas-peering-newvpc.template.yaml
+++ b/templates/mongodb-atlas-peering-newvpc.template.yaml
@@ -177,7 +177,7 @@ Parameters:
     - "US_WEST_2"
     - "SA_EAST_1"
     - "AP_SOUTH_1"
-    - "AP_EAST_2"
+    - "AP_EAST_1"
     - "AP_SOUTHEAST_1"
     - "AP_SOUTHEAST_2"
     - "AP_SOUTHEAST_3"

--- a/templates/mongodb-atlas-peering.template.yaml
+++ b/templates/mongodb-atlas-peering.template.yaml
@@ -131,6 +131,7 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
+      - "4.2"
       - "4.4"
       - "5.0"
       - "6.0"

--- a/templates/mongodb-atlas-peering.template.yaml
+++ b/templates/mongodb-atlas-peering.template.yaml
@@ -131,7 +131,6 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
-      - "4.2"
       - "4.4"
       - "5.0"
       - "6.0"

--- a/templates/mongodb-atlas-peering.template.yaml
+++ b/templates/mongodb-atlas-peering.template.yaml
@@ -111,7 +111,7 @@ Parameters:
       - "US_WEST_2"
       - "SA_EAST_1"
       - "AP_SOUTH_1"
-      - "AP_EAST_2"
+      - "AP_EAST_1"
       - "AP_SOUTHEAST_1"
       - "AP_SOUTHEAST_2"
       - "AP_SOUTHEAST_3"

--- a/templates/mongodb-atlas.base.template.yaml
+++ b/templates/mongodb-atlas.base.template.yaml
@@ -111,7 +111,7 @@ Parameters:
       - "US_WEST_2"
       - "SA_EAST_1"
       - "AP_SOUTH_1"
-      - "AP_EAST_2"
+      - "AP_EAST_1"
       - "AP_SOUTHEAST_1"
       - "AP_SOUTHEAST_2"
       - "AP_SOUTHEAST_3"

--- a/templates/mongodb-atlas.base.template.yaml
+++ b/templates/mongodb-atlas.base.template.yaml
@@ -131,6 +131,7 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
+    - "4.2"
     - "4.4"
     - "5.0"
     - "6.0"

--- a/templates/mongodb-atlas.base.template.yaml
+++ b/templates/mongodb-atlas.base.template.yaml
@@ -131,7 +131,6 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
-    - "4.2"
     - "4.4"
     - "5.0"
     - "6.0"

--- a/templates/mongodb-atlas.private-endpoint.template.yaml
+++ b/templates/mongodb-atlas.private-endpoint.template.yaml
@@ -143,7 +143,6 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
-      - "4.2"
       - "4.4"
       - "5.0"
       - "6.0"

--- a/templates/mongodb-atlas.private-endpoint.template.yaml
+++ b/templates/mongodb-atlas.private-endpoint.template.yaml
@@ -123,7 +123,7 @@ Parameters:
       - "US_WEST_2"
       - "SA_EAST_1"
       - "AP_SOUTH_1"
-      - "AP_EAST_2"
+      - "AP_EAST_1"
       - "AP_SOUTHEAST_1"
       - "AP_SOUTHEAST_2"
       - "AP_SOUTHEAST_3"

--- a/templates/mongodb-atlas.private-endpoint.template.yaml
+++ b/templates/mongodb-atlas.private-endpoint.template.yaml
@@ -143,6 +143,7 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
+      - "4.2"
       - "4.4"
       - "5.0"
       - "6.0"

--- a/templates/mongodb-atlas.template.yaml
+++ b/templates/mongodb-atlas.template.yaml
@@ -117,7 +117,6 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
-    - "4.2"
     - "4.4"
     - "5.0"
     - "6.0"

--- a/templates/mongodb-atlas.template.yaml
+++ b/templates/mongodb-atlas.template.yaml
@@ -99,7 +99,7 @@ Parameters:
       - "US_WEST_2"
       - "SA_EAST_1"
       - "AP_SOUTH_1"
-      - "AP_EAST_2"
+      - "AP_EAST_1"
       - "AP_SOUTHEAST_1"
       - "AP_SOUTHEAST_2"
       - "AP_NORTHEAST_1"

--- a/templates/mongodb-atlas.template.yaml
+++ b/templates/mongodb-atlas.template.yaml
@@ -117,10 +117,10 @@ Parameters:
     Type: String
     Default: "5.0"
     AllowedValues:
-    - "4.0"
     - "4.2"
     - "4.4"
     - "5.0"
+    - "6.0"
   DatabaseUserRoleDatabaseName:
     Description: Database User Role Database Name
     Type: String


### PR DESCRIPTION
**Description of changes:**
While testing the quickstart templates, I noticed the templates are allowing the region `AP_EAST_2` which is not available according to our [documentation](https://www.mongodb.com/docs/atlas/reference/amazon-aws/) and the MDW versions 4.2 and 6.0 were missing.

This PR updates the template to use `AP_EAST_1` and adds MDB version 4.2 and 6.0

**Other Info:**
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
