### PR TITLE
INTMDB-695: Add template to create the IAM role to run the quickstart

### DIFF
--- a/templates/execution-role.yaml
+++ b/templates/execution-role.yaml
@@ -1,0 +1,49 @@
+# This Template creates the IAM role to use to run the quickstart template on a CFN stack
+Resources:
+ AtlasQuickstartIAMRole:
+  Type: 'AWS::IAM::Role'
+  Properties:
+   AssumeRolePolicyDocument:
+    Version: '2012-10-17'
+    Statement:
+    - Effect: Allow
+      Principal:
+       Service:
+       - "lambda.amazonaws.com"
+       - "resources.cloudformation.amazonaws.com"
+       - "cloudformation.amazonaws.com"
+      Action: sts:AssumeRole
+   Path: /
+   Policies:
+   - PolicyName: AtlasQuickstartPolicy
+     PolicyDocument:
+      Version: '2012-10-17'
+      Statement:
+      - Effect: Allow
+        Action:
+        - iam:PassRole
+        - iam:DeleteRolePolicy
+        - iam:AttachRolePolicy
+        - iam:CreateRole
+        - iam:PutRolePolicy
+        - iam:DeleteRole
+        - iam:GetRole
+        - iam:GetRolePolicy
+        - iam:DetachRolePolicy
+        Resource: '*'
+      - Effect: Allow
+        Action: cloudformation:*
+        Resource: '*'
+      - Effect: Allow
+        Action: ec2:*
+        Resource: '*'
+      - Effect: Allow
+        Action:
+        - secretsmanager:CreateSecret
+        - secretsmanager:DeleteSecret
+        - secretsmanager:DescribeSecret
+        - secretsmanager:GetSecretValue
+        - secretsmanager:ListSecrets
+        - secretsmanager:PutSecretValue
+        - secretsmanager:TagResource
+        Resource: '*'

--- a/templates/execution-role.yaml
+++ b/templates/execution-role.yaml
@@ -1,4 +1,5 @@
-# This Template creates the IAM role to use to run the quickstart template on a CFN stack
+AWSTemplateFormatVersion: '2010-09-09'
+Description: This Template creates the IAM role to use to run the quickstart template on a CFN stack (qs-1tq8f0hrt)
 Resources:
  AtlasQuickstartIAMRole:
   Type: 'AWS::IAM::Role'


### PR DESCRIPTION


***Description of changes:***
This PR adds the `execute-role.yaml` template to use to create the IAM role to run the quickstart template in a CFN stack

![Screenshot 2023-03-23 at 09 14 19](https://user-images.githubusercontent.com/5663078/227157031-d96b26d8-74f4-49a9-a63c-a2ef237f7390.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
