### PR TITLE
HELP-44836: [Atlas] Customer reports error rolling back network container using AWS CDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ taskcat_outputs/
 .taskcat/
 *.zip
 .idea
+index.html

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ taskcat_outputs/
 *.zip
 .idea
 index.html
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ taskcat_outputs/
 *.zip
 .idea
 index.html
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ taskcat_outputs/
 .taskcat/
 *.zip
 .idea
-index.html

--- a/templates/mongodb-atlas-peering.template.yaml
+++ b/templates/mongodb-atlas-peering.template.yaml
@@ -188,7 +188,6 @@ Resources:
           Comment: "Testing open all ips"
   AtlasNetworkPeering:
     Type: MongoDB::Atlas::NetworkPeering
-    DependsOn: NetworkContainer
     Properties:
       ProjectId: !GetAtt "AtlasProject.Id"
       Profile:  !Ref "Profile"
@@ -199,6 +198,7 @@ Resources:
       ContainerId: !GetAtt "NetworkContainer.Id"
   AtlasCluster:
     Type: MongoDB::Atlas::Cluster
+    DependsOn: NetworkContainer # Important to wait for the Network Container, otherwise the network container deletion will fail when deleting the stack
     Properties:
       Profile:  !Ref "Profile"
       ProjectId: !GetAtt "AtlasProject.Id"
@@ -245,7 +245,6 @@ Resources:
           Type: "CLUSTER"
   NetworkContainer:
     Type: MongoDB::Atlas::NetworkContainer
-    DependsOn: AtlasCluster
     Properties:
       Profile:  !Ref "Profile"
       AtlasCidrBlock: !Ref AtlasCidrBlock


### PR DESCRIPTION

*Description of changes:*
This PR updates the Cluster resource to `DependsOn` the NetworkContainer resource. The main reason is that during stack deletion, the NetworkContainer resource deletion will fail if the cluster is not deleted first.

Error Message:
```bash
Resource handler returned message: "Error getting resource : DELETE https://cloud.mongodb.com/api/atlas/v1.0/groups/64428628d6219d50bbe8d143/containers/6442966d72899020b62006eb: *409 (request "CONTAINERS_IN_USE")* Cannot modify in use containers. The container still contained resources." (*RequestToken: 64f7ac61-f026-166f-b40a-4f5fa23d50a6*, HandlerErrorCode: InternalFailure).
```
