### PR TITLE
feat: Quick start without VPC peering

### DIFF
--- a/templates/activate-mongodb-atlas-resources.template.yaml
+++ b/templates/activate-mongodb-atlas-resources.template.yaml
@@ -53,7 +53,7 @@ Resources:
   ActivateServerlessInstanceType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ServerlessInstance' ] ]
+      PublicTypeArn: !Sub 'arn:aws:cloudformation:${Region}::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ServerlessInstance'
       Type: RESOURCE
       TypeName: MongoDB::Atlas::ServerlessInstance
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn

--- a/templates/activate-mongodb-atlas-resources.template.yaml
+++ b/templates/activate-mongodb-atlas-resources.template.yaml
@@ -14,6 +14,11 @@ Parameters:
     Description: The AWS Region where resources would be activated
     Type: String
     AllowedValues:
+    - "ap-south-2"
+    - "ap-southeast-4"
+    - "eu-central-2"
+    - "eu-south-2"
+    - "me-central-1"
     - "us-east-1"
     - "us-east-2"
     - "ca-central-1"
@@ -44,6 +49,13 @@ Resources:
       PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-Cluster' ] ]
       Type: RESOURCE
       TypeName: MongoDB::Atlas::Cluster
+      ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
+  ActivateServerlessInstanceType:
+    Type: AWS::CloudFormation::TypeActivation
+    Properties:
+      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ServerlessInstance' ] ]
+      Type: RESOURCE
+      TypeName: MongoDB::Atlas::ServerlessInstance
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateProjectIpAccessListType:
     Type: AWS::CloudFormation::TypeActivation

--- a/templates/activate-mongodb-atlas-resources.template.yaml
+++ b/templates/activate-mongodb-atlas-resources.template.yaml
@@ -8,6 +8,10 @@ Metadata:
           default: MongoDB Region
         Parameters:
           - Region
+Mappings:
+  DefaultConfiguration:
+    MongoDB:
+      PublisherID: bb989456c78c398a858fef18f2ca1bfc1fbba082
 Parameters:
   Region:
     Default: us-east-1
@@ -46,57 +50,97 @@ Resources:
   ActivateClusterType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-Cluster' ] ]
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-Cluster'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
       Type: RESOURCE
       TypeName: MongoDB::Atlas::Cluster
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateServerlessInstanceType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Sub 'arn:aws:cloudformation:${Region}::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ServerlessInstance'
-      Type: RESOURCE
+      PublicTypeArn: !Sub 
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-ServerlessInstance'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::ServerlessInstance
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateProjectIpAccessListType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ProjectIpAccessList' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-ProjectIpAccessList'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::ProjectIpAccessList
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateDatabaseUserType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-DatabaseUser' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-DatabaseUser'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::DatabaseUser
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateProjectType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-Project' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-Project'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::Project
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateNetworkPeeringType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-NetworkPeering' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-NetworkPeering'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::NetworkPeering
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivatePrivateEndpointType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-PrivateEndpoint' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-PrivateEndpoint'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::PrivateEndpoint
       ExecutionRoleArn: !GetAtt MongoDBPrivateEndpointExecutionRole.Arn
   ActivateNetworkContainerType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-NetworkContainer' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-NetworkContainer'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::NetworkContainer
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   MongoDBCustomResourceExecutionRole:

--- a/templates/mongodb-atlas-main.template.yaml
+++ b/templates/mongodb-atlas-main.template.yaml
@@ -221,7 +221,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub
-        - 'https://mongodbtemplate.s3.us-west-2.amazonaws.com/stacktemplate/activate-mongodb-atlas-resources.template.yaml'
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/activate-mongodb-atlas-resources.template.yaml'
         - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
@@ -235,7 +235,7 @@ Resources:
         - ''
     Properties:
       TemplateURL: !Sub
-        - 'https://mongodbtemplate.s3.us-west-2.amazonaws.com/stacktemplate/mongodb-atlas.template.yaml'
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/mongodb-atlas.template.yaml'
         - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:

--- a/templates/mongodb-atlas-main.template.yaml
+++ b/templates/mongodb-atlas-main.template.yaml
@@ -34,8 +34,8 @@ Metadata:
       Condition: CreateCluster
       Parameters:
       - ClusterMongoDBMajorVersion
-      - ClusterName
-      - ClusterRegion
+      - InstanceName
+      - Region
       - ClusterInstanceSize
     - Label:
         default: Atlas Serverless configuration
@@ -48,7 +48,6 @@ Metadata:
         default: AWS Quick Start configuration
       Parameters:
       - QSS3BucketName
-      - QSS3KeyPrefix
       - QSS3BucketRegion
     ParameterLabels:
       Profile:
@@ -61,16 +60,14 @@ Metadata:
         default: Name of new Atlas project
       ClusterMongoDBMajorVersion:
         default: MongoDB version
-      ClusterName:
+      InstanceName:
         default: Name of new cluster
-      ClusterRegion:
+      Region:
         default: AWS Region for Atlas cluster
       ClusterInstanceSize:
         default: MongoDB Atlas instance size
       QSS3BucketName:
         default: Quick Start S3 bucket name
-      QSS3KeyPrefix:
-        default: Quick Start S3 key prefix
       QSS3BucketRegion:
         default: Quick Start S3 bucket Region
       DatabaseUserName:
@@ -182,15 +179,6 @@ Parameters:
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start
       or end with a hyphen (-).
     Type: String
-  QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/.]*$
-    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), and forward slashes (/).
-    Default: quickstart-mongodb-atlas/
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
-      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
-      forward slashes (/).
-    Type: String
   QSS3BucketRegion:
     Default: 'us-east-1'
     Description: AWS Region where the Quick Start S3 bucket (QSS3BucketName) is
@@ -211,7 +199,7 @@ Parameters:
     AllowedValues: 
       - "true"
       - "false"
-    Default: false
+    Default: "false"
   ServerlessContinuousBackupEnabled: 
     Type: String
     Description: Flag that indicates whether the serverless instances uses Serverless Continuous Backup. If this parameter is false the serverless instance uses Basic Backup. | Option | Description | |---|---| | Serverless Continuous Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and lets you restore the data from a selected point in time within the last 72 hours. Atlas also takes daily snapshots and retains these daily snapshots for 35 days. To learn more see Serverless Instance Costs. | | Basic Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and retains only the two most recent snapshots. You can use this option for free. 
@@ -219,7 +207,7 @@ Parameters:
     AllowedValues: 
       - "true"
       - "false"
-    Default: true
+    Default: "true"
   DatabasePassword:
     Description: MongoDB Atlas Database User Password.
     Type: String

--- a/templates/mongodb-atlas-main.template.yaml
+++ b/templates/mongodb-atlas-main.template.yaml
@@ -12,7 +12,7 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
     - Label:
-        default: Instance to be created
+        default: Instance Configuration
       Parameters:
       - InstanceType
       - InstanceName
@@ -167,6 +167,15 @@ Parameters:
     AllowedValues:
       - "No"
       - "Yes"
+  QSS3KeyPrefix:
+      AllowedPattern: ^[0-9a-zA-Z-/.]*$
+      ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
+        uppercase letters, hyphens (-), and forward slashes (/).
+      Default: quickstart-mongodb-atlas/
+      Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
+        can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+        forward slashes (/).
+      Type: String
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: Quick Start bucket name can include numbers, lowercase

--- a/templates/mongodb-atlas-main.template.yaml
+++ b/templates/mongodb-atlas-main.template.yaml
@@ -12,6 +12,12 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
     - Label:
+        default: Instance to be created
+      Parameters:
+      - InstanceType
+      - InstanceName
+      - Region
+    - Label:
         default: MongoDB Atlas API key configuration
       Parameters:
       - Profile
@@ -21,12 +27,23 @@ Metadata:
       Parameters:
       - ActivateMongoDBResources
       - ProjectName
+      - DatabaseUserName
+      - DatabasePassword
+    - Label:
+        default: Atlas Cluster configuration
+      Condition: CreateCluster
+      Parameters:
       - ClusterMongoDBMajorVersion
       - ClusterName
       - ClusterRegion
       - ClusterInstanceSize
-      - DatabaseUserName
-      - DatabasePassword
+    - Label:
+        default: Atlas Serverless configuration
+      Condition: CreateServerless
+      Parameters:
+      - ServerlessProviderName
+      - ServerlessTerminationProtectionEnabled
+      - ServerlessContinuousBackupEnabled
     - Label:
         default: AWS Quick Start configuration
       Parameters:
@@ -61,6 +78,13 @@ Metadata:
       DatabasePassword:
         default: MongoDB Atlas Database User Password
 Parameters:
+  InstanceType:
+    Description: 'choose wich instance you want to create'
+    Type: String
+    Default: 'Dedicated Cluster'
+    AllowedValues:
+      - 'Dedicated Cluster'
+      - 'Serverless Instance'
   Profile:
     Description: "A secret with name cfn/atlas/profile/{Profile}"
     Type: String
@@ -73,10 +97,10 @@ Parameters:
     Description: "Name of the project."
     Type: String
     Default: "aws-quickstart"
-  ClusterName:
+  InstanceName:
     Description: Name of the cluster as it appears in Atlas. This name cannot be changed after the cluster is created.
     Type: String
-    Default: "Cluster-1"
+    Default: "Cluster/Serverless Name"
   ClusterInstanceSize:
     Default: "M10"
     Description: "Atlas provides different cluster tiers, each with a default storage capacity and RAM size. The cluster you choose is used for all data-bearing hosts in your cluster tier (see https://docs.atlas.mongodb.com/reference/amazon-aws/#amazon-aws)."
@@ -106,7 +130,7 @@ Parameters:
     - "R400"
     - "M400_NVME"
     - "R700"
-  ClusterRegion:
+  Region:
     Default: "US_EAST_1"
     Description: AWS Region where the Atlas database runs.
     Type: String
@@ -176,6 +200,26 @@ Parameters:
     Description: MongoDB Atlas Database User  Name.
     Type: String
     Default: "testUser"
+  ServerlessProviderName:
+    Type: String
+    Description: Human-readable label that identifies the cloud service provider. Used only on the Serverless Instance
+    Default: "SERVERLESS"
+  ServerlessTerminationProtectionEnabled: 
+    Type: String
+    Description: Flag that indicates whether termination protection is enabled on the serverless instance. If set to true MongoDB Cloud won't delete the serverless instance. If set to false MongoDB cloud will delete the serverless instance.
+    ConstraintDescription: boolean
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: false
+  ServerlessContinuousBackupEnabled: 
+    Type: String
+    Description: Flag that indicates whether the serverless instances uses Serverless Continuous Backup. If this parameter is false the serverless instance uses Basic Backup. | Option | Description | |---|---| | Serverless Continuous Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and lets you restore the data from a selected point in time within the last 72 hours. Atlas also takes daily snapshots and retains these daily snapshots for 35 days. To learn more see Serverless Instance Costs. | | Basic Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and retains only the two most recent snapshots. You can use this option for free. 
+    ConstraintDescription: boolean
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: true
   DatabasePassword:
     Description: MongoDB Atlas Database User Password.
     Type: String
@@ -183,13 +227,15 @@ Parameters:
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   ActivateResources: !Equals [!Ref ActivateMongoDBResources, 'Yes']
+  CreateCluster: !Equals [!Ref InstanceType, 'Dedicated Cluster']
+  CreateServerless: !Equals [!Ref InstanceType, 'Serverless Instance']
 Resources:
   ActivateAtlasResources:
     Condition: ActivateResources
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub
-        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/activate-mongodb-atlas-resources.template.yaml'
+        - 'https://mongodbtemplate.s3.us-west-2.amazonaws.com/stacktemplate/activate-mongodb-atlas-resources.template.yaml'
         - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
@@ -203,19 +249,23 @@ Resources:
         - ''
     Properties:
       TemplateURL: !Sub
-        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/mongodb-atlas.template.yaml'
+        - 'https://mongodbtemplate.s3.us-west-2.amazonaws.com/stacktemplate/mongodb-atlas.template.yaml'
         - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
-        ClusterInstanceSize: !Ref ClusterInstanceSize
-        ClusterMongoDBMajorVersion: !Ref ClusterMongoDBMajorVersion
         ProjectName: !Ref ProjectName
-        ClusterName: !Ref ClusterName
-        ClusterRegion: !Ref ClusterRegion
+        InstanceName: !Ref InstanceName
+        Region: !Ref Region
         OrgId: !Ref OrgId
         Profile: !Ref Profile
+        InstanceType: !Ref InstanceType
         DatabaseUserName: !Ref DatabaseUserName
         DatabasePassword: !Ref DatabasePassword
+        ClusterInstanceSize: !Ref ClusterInstanceSize
+        ClusterMongoDBMajorVersion: !Ref ClusterMongoDBMajorVersion
+        ServerlessProviderName: !Ref ServerlessProviderName
+        ServerlessTerminationProtectionEnabled: !Ref ServerlessTerminationProtectionEnabled
+        ServerlessContinuousBackupEnabled: !Ref ServerlessContinuousBackupEnabled
 Outputs:
   AtlasIAMRole:
     Description: "ARN for AWS IAM role database cluster access."
@@ -230,11 +280,14 @@ Outputs:
     Description: "Atlas project IP access list."
     Value: !GetAtt "Atlas.Outputs.AtlasProjectIPAccessList"
   AtlasCluster:
+    Condition: CreateCluster
     Description: "Information about your Atlas cluster."
     Value: !GetAtt "Atlas.Outputs.AtlasCluster"
-  ClusterState:
-    Description: "State of your MongoDB cluster."
-    Value: !GetAtt "Atlas.Outputs.ClusterState"
   ClusterSrvAddress:
+    Condition: CreateCluster
     Description: "Hostname for the mongodb+srv:// connection string."
     Value: !GetAtt "Atlas.Outputs.ClusterSrvAddress"
+  ServerlessStr:
+    Condition: CreateServerless
+    Description: "Id of the serverless Instance."
+    Value: !GetAtt "Atlas.Outputs.ServerlessConnectionStr"

--- a/templates/mongodb-atlas-main.template.yaml
+++ b/templates/mongodb-atlas-main.template.yaml
@@ -31,7 +31,6 @@ Metadata:
       - DatabasePassword
     - Label:
         default: Atlas Cluster configuration
-      Condition: CreateCluster
       Parameters:
       - ClusterMongoDBMajorVersion
       - InstanceName
@@ -39,7 +38,6 @@ Metadata:
       - ClusterInstanceSize
     - Label:
         default: Atlas Serverless configuration
-      Condition: CreateServerless
       Parameters:
       - ServerlessProviderName
       - ServerlessTerminationProtectionEnabled

--- a/templates/mongodb-atlas.template.yaml
+++ b/templates/mongodb-atlas.template.yaml
@@ -58,7 +58,7 @@ Parameters:
     AllowedValues: 
       - "true"
       - "false"
-    Default: false
+    Default: "false"
   ServerlessContinuousBackupEnabled: 
     Type: String
     Description: Flag that indicates whether the serverless instances uses Serverless Continuous Backup. If this parameter is false the serverless instance uses Basic Backup. | Option | Description | |---|---| | Serverless Continuous Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and lets you restore the data from a selected point in time within the last 72 hours. Atlas also takes daily snapshots and retains these daily snapshots for 35 days. To learn more see Serverless Instance Costs. | | Basic Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and retains only the two most recent snapshots. You can use this option for free. 
@@ -66,7 +66,7 @@ Parameters:
     AllowedValues: 
       - "true"
       - "false"
-    Default: true
+    Default: "true"
   Profile:
     Description: "A secret with name cfn/atlas/profile/{Profile}"
     Type: String

--- a/templates/mongodb-atlas.template.yaml
+++ b/templates/mongodb-atlas.template.yaml
@@ -14,8 +14,8 @@ Metadata:
         default: MongoDB Atlas Configuration
       Parameters:
       - ProjectName
-      - ClusterName
-      - ClusterRegion
+      - InstanceName
+      - Region
       - ClusterInstanceSize
       - DatabaseUserRoleDatabaseName
       - DatabaseUserName
@@ -27,10 +27,10 @@ Metadata:
         default: MongoDB Atlas API OrgId
       ProjectName:
         default: Name of new Atlas Project
-      ClusterName:
-        default: Name of new cluster
-      ClusterRegion:
-        default: The AWS Region for Atlas Cluster
+      InstanceName:
+        default: Name of new cluster or the serverless Instance to be created
+      Region:
+        default: The AWS Region for Atlas Cluster or the serverless instance created
       ClusterInstanceSize:
         default: MongoDB Atlas Instance Size
       DatabaseUserRoleDatabaseName:
@@ -40,6 +40,33 @@ Metadata:
       DatabasePassword:
         default: MongoDB Atlas Database User Password
 Parameters:
+  InstanceType:
+    Description: 'choose wich instance you want to create'
+    Type: String
+    Default: 'Dedicated Cluster'
+    AllowedValues:
+      - 'Dedicated Cluster'
+      - 'Serverless Instance'
+  ServerlessProviderName:
+    Type: String
+    Description: Human-readable label that identifies the cloud service provider. Used only on the Serverless Instance
+    Default: "SERVERLESS"
+  ServerlessTerminationProtectionEnabled: 
+    Type: String
+    Description: Flag that indicates whether termination protection is enabled on the serverless instance. If set to true MongoDB Cloud won't delete the serverless instance. If set to false MongoDB cloud will delete the serverless instance.
+    ConstraintDescription: boolean
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: false
+  ServerlessContinuousBackupEnabled: 
+    Type: String
+    Description: Flag that indicates whether the serverless instances uses Serverless Continuous Backup. If this parameter is false the serverless instance uses Basic Backup. | Option | Description | |---|---| | Serverless Continuous Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and lets you restore the data from a selected point in time within the last 72 hours. Atlas also takes daily snapshots and retains these daily snapshots for 35 days. To learn more see Serverless Instance Costs. | | Basic Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and retains only the two most recent snapshots. You can use this option for free. 
+    ConstraintDescription: boolean
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: true
   Profile:
     Description: "A secret with name cfn/atlas/profile/{Profile}"
     Type: String
@@ -52,8 +79,8 @@ Parameters:
     Description: "The name of the project."
     Type: String
     Default: "aws-quickstart"
-  ClusterName:
-    Description: Name of the cluster as it appears in Atlas. Once the cluster is created,
+  InstanceName:
+    Description: Name of the cluster or the serverless instances as it appears in Atlas. Once the cluster/serverlessInstance is created,
       its name cannot be changed.
     Type: String
     Default: "Cluster-1"
@@ -86,7 +113,7 @@ Parameters:
       - "R400"
       - "M400_NVME"
       - "R700"
-  ClusterRegion:
+  Region:
     Default: "US_EAST_1"
     Description: AWS Region where the Atlas database runs.
     Type: String
@@ -131,6 +158,9 @@ Parameters:
     Description: MongoDB Atlas Database User Password.
     Type: String
     NoEcho: true
+Conditions:
+  CreateCluster: !Equals [!Ref InstanceType, 'Dedicated Cluster']
+  CreateServerless: !Equals [!Ref InstanceType, 'Serverless Instance']
 Resources:
   AtlasIAMRole:
     Type: AWS::IAM::Role
@@ -165,12 +195,25 @@ Resources:
       AccessList:
       - IPAddress: "0.0.0.0/0"
         Comment: "Testing open all ips"
+  AtlasServerlessInstance:
+    Type: MongoDB::Atlas::ServerlessInstance
+    Condition: CreateServerless
+    Properties:
+      Name: !Ref "InstanceName"
+      Profile: !Ref "Profile"
+      ProjectID: !GetAtt "AtlasProject.Id"
+      ProviderSettings:
+        RegionName: !Ref "Region"
+        ProviderName: !Ref "ServerlessProviderName"
+      TerminationProtectionEnabled: !Ref "ServerlessTerminationProtectionEnabled"
+      ContinuousBackupEnabled : !Ref "ServerlessContinuousBackupEnabled"
   AtlasCluster:
     Type: MongoDB::Atlas::Cluster
+    Condition: CreateCluster
     Properties:
       Profile: !Ref "Profile"
       ProjectId: !GetAtt "AtlasProject.Id"
-      Name: !Ref "ClusterName"
+      Name: !Ref "InstanceName"
       MongoDBMajorVersion: !Ref "ClusterMongoDBMajorVersion"
       ClusterType: "REPLICASET"
       ReplicationSpecs:
@@ -195,7 +238,7 @@ Resources:
                 InstanceSize: !Ref "ClusterInstanceSize"
                 NodeCount: '3'
               Priority: '7'
-              RegionName: !Ref ClusterRegion
+              RegionName: !Ref Region
   AtlasDatabaseUser:
     Type: MongoDB::Atlas::DatabaseUser
     Properties:
@@ -208,7 +251,7 @@ Resources:
       - RoleName: "readWrite"
         DatabaseName: !Ref "DatabaseUserRoleDatabaseName"
       Scopes:
-      - Name: !Ref "ClusterName"
+      - Name: !Ref "InstanceName"
         Type: "CLUSTER"
 Outputs:
   AtlasIAMRole:
@@ -232,18 +275,24 @@ Outputs:
     Export:
       Name: !Join [ "-", [ !Ref "AWS::StackName","AtlasProjectIPAccessList" ] ]
   AtlasCluster:
+    Condition: CreateCluster
     Description: "Info on your Atlas Cluster"
     Value: !Ref AtlasCluster
     Export:
       Name: !Join [ "-", [ !Ref "AWS::StackName","AtlasCluster" ] ]
   ClusterState:
+    Condition: CreateCluster
     Description: "Cluster State"
     Value: !GetAtt "AtlasCluster.StateName"
     Export:
       Name: !Join [ "-", [ !Ref "AWS::StackName","ClusterState" ] ]
   ClusterSrvAddress:
+    Condition: CreateCluster
     Description: "Hostname for mongodb+srv:// connection string"
     Value: !GetAtt "AtlasCluster.ConnectionStrings.StandardSrv"
     Export:
       Name: !Join [ "-", [ !Ref "AWS::StackName","ClusterSrvAddress" ] ]
-
+  ServerlessConnectionStr:
+    Condition: CreateServerless
+    Description: "Id of the Serverless Instances"
+    Value: !GetAtt "AtlasServerlessInstance.ConnectionStrings.StandardSrv"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Template updated to Deploy MongoDB Atlas without VPC peering.

This PR is used to create cluster or the serverless Instances with the single stack.
So we have added serverless instance parameter based on the condition in the stack  template will create either cluster or serverless instance

Also actiavtes the required public resources.
**Stack created with sample Template**

<img width="890" alt="Screenshot 2023-09-12 at 15 21 14" src="https://github.com/aws-quickstart/quickstart-mongodb-atlas/assets/109083730/41c2871f-a9ff-467a-a3fc-4b0120772bd4">

<img width="890" alt="Screenshot 2023-09-12 at 15 21 42" src="https://github.com/aws-quickstart/quickstart-mongodb-atlas/assets/109083730/84532d6c-c633-4db7-9bc4-d6d8458b4df4">

**Response on the Atlas Screen for the reference:**

<img width="1508" alt="Screenshot 2023-09-12 at 15 27 05" src="https://github.com/aws-quickstart/quickstart-mongodb-atlas/assets/109083730/77ba003b-9ece-49e5-b652-320748a50185">

<img width="1508" alt="Screenshot 2023-09-12 at 15 27 23" src="https://github.com/aws-quickstart/quickstart-mongodb-atlas/assets/109083730/2e62e13d-497d-4847-90b8-90b6b8d8d2af">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
