### PR TITLE
serverlessprivate endpoint quick start

### DIFF
--- a/templates/activate-mongodb-atlas-resources.template.yaml
+++ b/templates/activate-mongodb-atlas-resources.template.yaml
@@ -38,6 +38,20 @@ Parameters:
     - "me-south-1"
     - "af-south-1"
 Resources:
+  ActivateServerlessInstanceType:
+    Type: AWS::CloudFormation::TypeActivation
+    Properties:
+      PublicTypeArn: !Sub 'arn:aws:cloudformation:${Region}::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ServerlessInstance'
+      Type: RESOURCE
+      TypeName: MongoDB::Atlas::ServerlessInstance
+      ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
+  ActivateServerlessPrivateEndpointType:
+    Type: AWS::CloudFormation::TypeActivation
+    Properties:
+      PublicTypeArn: !Sub 'arn:aws:cloudformation:${Region}::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ServerlessPrivateEndpoint'
+      Type: RESOURCE
+      TypeName: MongoDB::Atlas::ServerlessPrivateEndpoint
+      ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateClusterType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:

--- a/templates/activate-mongodb-atlas-resources.template.yaml
+++ b/templates/activate-mongodb-atlas-resources.template.yaml
@@ -8,12 +8,21 @@ Metadata:
           default: MongoDB Region
         Parameters:
           - Region
+Mappings:
+  DefaultConfiguration:
+    MongoDB:
+      PublisherID: bb989456c78c398a858fef18f2ca1bfc1fbba082
 Parameters:
   Region:
     Default: us-east-1
     Description: The AWS Region where resources would be activated
     Type: String
     AllowedValues:
+    - "ap-south-2"
+    - "ap-southeast-4"
+    - "eu-central-2"
+    - "eu-south-2"
+    - "me-central-1"
     - "us-east-1"
     - "us-east-2"
     - "ca-central-1"
@@ -38,67 +47,100 @@ Parameters:
     - "me-south-1"
     - "af-south-1"
 Resources:
-  ActivateServerlessInstanceType:
-    Type: AWS::CloudFormation::TypeActivation
-    Properties:
-      PublicTypeArn: !Sub 'arn:aws:cloudformation:${Region}::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ServerlessInstance'
-      Type: RESOURCE
-      TypeName: MongoDB::Atlas::ServerlessInstance
-      ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
-  ActivateServerlessPrivateEndpointType:
-    Type: AWS::CloudFormation::TypeActivation
-    Properties:
-      PublicTypeArn: !Sub 'arn:aws:cloudformation:${Region}::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ServerlessPrivateEndpoint'
-      Type: RESOURCE
-      TypeName: MongoDB::Atlas::ServerlessPrivateEndpoint
-      ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateClusterType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-Cluster' ] ]
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-Cluster'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
       Type: RESOURCE
       TypeName: MongoDB::Atlas::Cluster
+      ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
+  ActivateServerlessInstanceType:
+    Type: AWS::CloudFormation::TypeActivation
+    Properties:
+      PublicTypeArn: !Sub 
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-ServerlessInstance'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
+      TypeName: MongoDB::Atlas::ServerlessInstance
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateProjectIpAccessListType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ProjectIpAccessList' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-ProjectIpAccessList'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::ProjectIpAccessList
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateDatabaseUserType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-DatabaseUser' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-DatabaseUser'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::DatabaseUser
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateProjectType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-Project' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-Project'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::Project
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivateNetworkPeeringType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-NetworkPeering' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-NetworkPeering'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::NetworkPeering
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   ActivatePrivateEndpointType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-PrivateEndpoint' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-PrivateEndpoint'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::PrivateEndpoint
       ExecutionRoleArn: !GetAtt MongoDBPrivateEndpointExecutionRole.Arn
   ActivateNetworkContainerType:
     Type: AWS::CloudFormation::TypeActivation
     Properties:
-      PublicTypeArn: !Join [ "", [ 'arn:aws:cloudformation:',!Ref "Region",'::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-NetworkContainer' ] ]
-      Type: RESOURCE
+      PublicTypeArn: !Sub
+      - 'arn:aws:cloudformation:${Region}::type/resource/${publisher_id}/MongoDB-Atlas-NetworkContainer'
+      - publisher_id: !FindInMap
+          - DefaultConfiguration
+          - MongoDB
+          - PublisherID
+        Type: RESOURCE
       TypeName: MongoDB::Atlas::NetworkContainer
       ExecutionRoleArn: !GetAtt MongoDBCustomResourceExecutionRole.Arn
   MongoDBCustomResourceExecutionRole:

--- a/templates/mongodb-atlas.base.template.yaml
+++ b/templates/mongodb-atlas.base.template.yaml
@@ -6,16 +6,22 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
     - Label:
-        default: MongoDB Atlas ApiKey Configuration
+        default: MongoDB Atlas Common Configuration
       Parameters:
+      - InstanceType
       - Profile
       - OrgId
-    - Label:
-        default: MongoDB Atlas Configuration
-      Parameters:
+      - InstanceName
+      - InstanceRegion
       - ProjectName
-      - ClusterName
-      - ClusterRegion
+    - Label:
+        default: MongoDB Atlas Serverless Private endpoint Configuration
+      Parameters:
+      - CreateAndAssignAWSPrivateEndpoint
+      - VpcId
+    - Label:
+        default: MongoDB Atlas Cluster Configuration
+      Parameters:
       - ClusterInstanceSize
       - DatabaseUserRoleDatabaseName
       - VPCCIDR
@@ -31,9 +37,9 @@ Metadata:
         default: MongoDB Atlas API OrgId
       ProjectName:
         default: Name of new Atlas Project
-      ClusterName:
+      InstanceName:
         default: Name of new cluster
-      ClusterRegion:
+      InstanceRegion:
         default: The AWS Region for Atlas Cluster
       ClusterInstanceSize:
         default: MongoDB Atlas Instance Size
@@ -52,6 +58,13 @@ Metadata:
       DatabasePassword:
           default: MongoDB Atlas Database User Password
 Parameters:
+  InstanceType:
+    Description: 'choose wich instance you want to create'
+    Type: String
+    Default: 'Dedicated Cluster'
+    AllowedValues:
+      - 'Dedicated Cluster'
+      - 'Serverless Instance'
   Profile:
     Description: "A secret with the cfn/atlas/profile/{Profile}"
     Type: String
@@ -64,11 +77,40 @@ Parameters:
     Description: "The name of the project."
     Type: String
     Default: "aws-quickstart"
-  ClusterName:
-    Description: Name of the cluster as it appears in Atlas. Once the cluster is created,
-      its name cannot be changed.
+  CreateAndAssignAWSPrivateEndpoint:
     Type: String
-    Default: "Cluster-1"
+    Description: "If true the resource will create the aws private endpoint and assign the Endpoint ID"
+    Default: "false"
+    AllowedValues:
+    - "true"
+    - "false"
+  VpcId:
+    Description: "String Representing the AWS VPC ID (like: vpc-xxxxxxxxxxxxxxxx) (Used For Creating the AWS VPC Endpoint)"
+    Type: String
+  ServerlessProviderName:
+    Type: String
+    Description: Human-readable label that identifies the cloud service provider. Used only on the Serverless Instance
+    Default: "SERVERLESS"
+  ServerlessTerminationProtectionEnabled: 
+    Type: String
+    Description: Flag that indicates whether termination protection is enabled on the serverless instance. If set to true MongoDB Cloud won't delete the serverless instance. If set to false MongoDB cloud will delete the serverless instance.
+    ConstraintDescription: boolean
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "false"
+  ServerlessContinuousBackupEnabled: 
+    Type: String
+    Description: Flag that indicates whether the serverless instances uses Serverless Continuous Backup. If this parameter is false the serverless instance uses Basic Backup. | Option | Description | |---|---| | Serverless Continuous Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and lets you restore the data from a selected point in time within the last 72 hours. Atlas also takes daily snapshots and retains these daily snapshots for 35 days. To learn more see Serverless Instance Costs. | | Basic Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and retains only the two most recent snapshots. You can use this option for free. 
+    ConstraintDescription: boolean
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "true"
+  InstanceName:
+    Description: Name of the cluster as it appears in Atlas. Once the cluster is created,its name cannot be changed.
+    Type: String
+    Default: "ServerlessInstance-Cluster-1"
   ClusterInstanceSize:
     Default: "M10"
     Description: Atlas provides different cluster tiers, each with a default storage capacity and RAM size. The cluster you select is used for all the data-bearing hosts in your cluster tier. See https://docs.atlas.mongodb.com/reference/amazon-aws/#amazon-aws.
@@ -98,7 +140,7 @@ Parameters:
     - "R400"
     - "M400_NVME"
     - "R700"
-  ClusterRegion:
+  InstanceRegion:
     Default: US_EAST_1
     Description: AWS Region where the Atlas database runs.
     Type: String
@@ -189,6 +231,9 @@ Parameters:
     Description: MongoDB Atlas Database User Password.
     Type: String
     NoEcho: true
+Conditions:
+  CreateCluster: !Equals [!Ref InstanceType, 'Dedicated Cluster']
+  CreateServerless: !Equals [!Ref InstanceType, 'Serverless Instance']
 Resources:
   AtlasIAMRole:
     Type: AWS::IAM::Role
@@ -223,12 +268,37 @@ Resources:
       AccessList:
       - IPAddress: "0.0.0.0/0"
         Comment: "Testing open all ips"
+  AtlasServerlessInstance:
+    Type: MongoDB::Atlas::ServerlessInstance
+    Condition: CreateServerless
+    Properties:
+      Name: !Ref InstanceName
+      Profile: !Ref "Profile"
+      ProjectID: !GetAtt "AtlasProject.Id"
+      ProviderSettings:
+        RegionName: !Ref InstanceRegion
+        ProviderName: !Ref ServerlessProviderName
+      TerminationProtectionEnabled: !Ref ServerlessTerminationProtectionEnabled
+      ContinuousBackupEnabled : !Ref ServerlessContinuousBackupEnabled
+  AtlasServerlessPrivateEndpoint:
+    Type: MongoDB::Atlas::ServerlessPrivateEndpoint
+    Condition: CreateServerless
+    DependsOn: AtlasServerlessInstance
+    Properties:
+      ProjectId: !GetAtt "AtlasProject.Id"
+      Profile: !Ref "Profile"
+      InstanceName: !Ref InstanceName
+      CreateAndAssignAWSPrivateEndpoint : !Ref CreateAndAssignAWSPrivateEndpoint
+      AwsPrivateEndpointConfigurationProperties:
+        VpcId: !Ref VpcId
+        Region: !Ref InstanceRegion
   AtlasCluster:
     Type: MongoDB::Atlas::Cluster
+    Condition: CreateCluster
     Properties:
       Profile: !Ref "Profile"
       ProjectId: !GetAtt "AtlasProject.Id"
-      Name: !Ref "ClusterName"
+      Name: !Ref "InstanceName"
       MongoDBMajorVersion: !Ref "ClusterMongoDBMajorVersion"
       ClusterType: "REPLICASET"
       ReplicationSpecs:
@@ -249,7 +319,7 @@ Resources:
                 InstanceSize: !Ref ClusterInstanceSize
                 NodeCount: '1'
               Priority: '7'
-              RegionName: !Ref ClusterRegion
+              RegionName: !Ref InstanceRegion
   AtlasDatabaseUser:
     Type: MongoDB::Atlas::DatabaseUser
     Properties:
@@ -262,10 +332,11 @@ Resources:
       - RoleName: "readWrite"
         DatabaseName: !Ref "DatabaseUserRoleDatabaseName"
       Scopes:
-      - Name: !Ref "ClusterName"
+      - Name: !Ref "InstanceName"
         Type: "CLUSTER"
   PrivateEndpoint:
     Type: MongoDB::Atlas::PrivateEndpoint
+    Condition: CreateCluster
     DependsOn: AtlasCluster
     Properties:
       GroupId: !GetAtt "AtlasProject.Id"
@@ -308,16 +379,13 @@ Outputs:
     Export:
       Name: !Join [ "-", [ !Ref "AWS::StackName","AtlasProjectIPAccessList" ] ]
   AtlasCluster:
+    Condition: CreateCluster
     Description: "Info on your Atlas Cluster"
     Value: !Ref AtlasCluster
     Export:
       Name: !Join [ "-", [ !Ref "AWS::StackName","AtlasCluster" ] ]
-  ClusterState:
-    Description: "Cluster State"
-    Value: !GetAtt "AtlasCluster.StateName"
-    Export:
-      Name: !Join [ "-", [ !Ref "AWS::StackName","ClusterState" ] ]
   ClusterSrvAddress:
+    Condition: CreateCluster
     Description: "Hostname for mongodb+srv:// connection string"
     Value: !GetAtt "AtlasCluster.ConnectionStrings.StandardSrv"
     Export:

--- a/templates/mongodb-atlas.private-endpoint.template.yaml
+++ b/templates/mongodb-atlas.private-endpoint.template.yaml
@@ -6,22 +6,26 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
+          default: MongoDB Atlas Common Configuration
+        Parameters:
+          - InstanceType
+          - Profile
+          - OrgId
+          - InstanceName
+          - InstanceRegion
+          - ProjectName
+      - Label:
           default: Network Configuration
         Parameters:
           - VPCCIDR
           - PrivateSubnetCIDR
           - VPCRegion
       - Label:
-          default: MongoDB Atlas ApiKey Configuration
-        Parameters:
-          - Profile
-          - OrgId
-      - Label:
           default: MongoDB Atlas Configuration
         Parameters:
           - ProjectName
-          - ClusterName
-          - ClusterRegion
+          - InstanceName
+          - InstanceRegion
           - ClusterInstanceSize
           - DatabaseUserRoleDatabaseName
           - ActivateMongoDBResources
@@ -41,9 +45,9 @@ Metadata:
         default: MongoDB Atlas API OrgId
       ProjectName:
         default: Name of new Atlas Project
-      ClusterName:
+      InstanceName:
         default: Name of new cluster
-      ClusterRegion:
+      InstanceRegion:
         default: The AWS Region for Atlas Cluster
       ClusterInstanceSize:
         default: MongoDB Atlas Instance Size
@@ -64,6 +68,13 @@ Metadata:
       DatabasePassword:
         default: MongoDB Atlas Database User Password
 Parameters:
+  InstanceType:
+    Description: 'choose wich instance you want to create'
+    Type: String
+    Default: 'Dedicated Cluster'
+    AllowedValues:
+      - 'Dedicated Cluster'
+      - 'Serverless Instance'
   Profile:
     Description: "A secret with the cfn/atlas/profile/{Profile}"
     Type: String
@@ -76,11 +87,41 @@ Parameters:
     Description: "The name of the project."
     Type: String
     Default: "aws-quickstart-pvt"
-  ClusterName:
+  CreateAndAssignAWSPrivateEndpoint:
+    Type: String
+    Description: "If true the resource will create the aws private endpoint and assign the Endpoint ID"
+    Default: "false"
+    AllowedValues:
+    - "true"
+    - "false"
+  VpcId:
+    Description: "String Representing the AWS VPC ID (like: vpc-xxxxxxxxxxxxxxxx) (Used For Creating the AWS VPC Endpoint)"
+    Type: String
+  ServerlessProviderName:
+    Type: String
+    Description: Human-readable label that identifies the cloud service provider. Used only on the Serverless Instance
+    Default: "SERVERLESS"
+  ServerlessTerminationProtectionEnabled: 
+    Type: String
+    Description: Flag that indicates whether termination protection is enabled on the serverless instance. If set to true MongoDB Cloud won't delete the serverless instance. If set to false MongoDB cloud will delete the serverless instance.
+    ConstraintDescription: boolean
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "false"
+  ServerlessContinuousBackupEnabled: 
+    Type: String
+    Description: Flag that indicates whether the serverless instances uses Serverless Continuous Backup. If this parameter is false the serverless instance uses Basic Backup. | Option | Description | |---|---| | Serverless Continuous Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and lets you restore the data from a selected point in time within the last 72 hours. Atlas also takes daily snapshots and retains these daily snapshots for 35 days. To learn more see Serverless Instance Costs. | | Basic Backup | Atlas takes incremental snapshots of the data in your serverless instance every six hours and retains only the two most recent snapshots. You can use this option for free. 
+    ConstraintDescription: boolean
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "true"
+  InstanceName:
     Description: Name of the cluster as it appears in Atlas. Once the cluster is created,
       its name cannot be changed.
     Type: String
-    Default: "Cluster-1"
+    Default: "Serverless-Cluster-1"
   ClusterInstanceSize:
     Default: "M10"
     Description: Atlas provides different cluster tiers, each with a default storage capacity and RAM size. The cluster you select is used for all the data-bearing hosts in your cluster tier. See https://docs.atlas.mongodb.com/reference/amazon-aws/#amazon-aws.
@@ -110,7 +151,7 @@ Parameters:
       - "R400"
       - "M400_NVME"
       - "R700"
-  ClusterRegion:
+  InstanceRegion:
     Default: US_EAST_1
     Description: AWS Region where the Atlas database runs.
     Type: String
@@ -235,9 +276,8 @@ Parameters:
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   ActivateResources: !Equals [!Ref ActivateMongoDBResources, 'Yes']
-
 Resources:
-  AtlasCluster:
+  Atlas:
     Type: AWS::CloudFormation::Stack
     Metadata:
       PseudoDependsOn: !If
@@ -253,8 +293,8 @@ Resources:
         ClusterInstanceSize: !Ref ClusterInstanceSize
         ClusterMongoDBMajorVersion: !Ref ClusterMongoDBMajorVersion
         ProjectName: !Ref ProjectName
-        ClusterName: !Ref ClusterName
-        ClusterRegion: !Ref ClusterRegion
+        InstanceName: !Ref InstanceName
+        InstanceRegion: !Ref InstanceRegion
         OrgId: !Ref OrgId
         Profile: !Ref Profile
         PrivateSubnetCIDR: !Ref PrivateSubnetCIDR
@@ -264,6 +304,13 @@ Resources:
         DatabaseUserRoleDatabaseName: !Ref DatabaseUserRoleDatabaseName
         DatabaseUserName: !Ref DatabaseUserName
         DatabasePassword: !Ref DatabasePassword
+        ServerlessProviderName: !Ref ServerlessProviderName
+        ServerlessTerminationProtectionEnabled: !Ref ServerlessTerminationProtectionEnabled
+        ServerlessContinuousBackupEnabled: !Ref ServerlessContinuousBackupEnabled
+        CreateAndAssignAWSPrivateEndpoint : !Ref CreateAndAssignAWSPrivateEndpoint
+        VpcId: !Ref VpcId
+        InstanceType: !Ref InstanceType
+        
   ActivateAtlasResources:
     Condition: ActivateResources
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Template updated to Deploy MongoDB Atlas with Private Endpoint.

This PR is used to create cluster with private endpoint or the serverless Instances with serverless private endpoint in the single stack.
So we have added serverless instance, serverless private endpoint parameter based on the condition in the stack template will create either cluster private endpoint or serverless instance private endpoint

Also actiavtes the required public CFN resources.
Stack created with sample Template

<img width="1508" alt="Screenshot 2023-09-14 at 23 34 51" src="https://github.com/aws-quickstart/quickstart-mongodb-atlas/assets/109083730/551cad0b-be83-42a9-b213-67aca0177519">

<img width="1508" alt="Screenshot 2023-09-14 at 23 35 14" src="https://github.com/aws-quickstart/quickstart-mongodb-atlas/assets/109083730/da94ca6b-2670-4b25-bde9-fd1f6f9c95ca">

<img width="1508" alt="Screenshot 2023-09-14 at 23 35 34" src="https://github.com/aws-quickstart/quickstart-mongodb-atlas/assets/109083730/4beb971f-c6e4-441b-8787-d09153747c0e">

<img width="1508" alt="Screenshot 2023-09-14 at 23 36 09" src="https://github.com/aws-quickstart/quickstart-mongodb-atlas/assets/109083730/1aa6f2d8-5348-4590-a86f-9b986fdc6314">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
