### PR TITLE
use MONGODB_ATLAS_* instead of ATLAS_* variables

### DIFF
--- a/scripts/create.taskcat_overrides.sh
+++ b/scripts/create.taskcat_overrides.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 cat << EOF
-PublicKey: "${ATLAS_PUBLIC_KEY}"
-PrivateKey: "${ATLAS_PRIVATE_KEY}"
-OrgId: "${ATLAS_ORG_ID}"
+PublicKey: "${MONGODB_ATLAS_PUBLIC_KEY}"
+PrivateKey: "${MONGODB_ATLAS_PRIVATE_KEY}"
+OrgId: "${MONGODB_ATLAS_ORG_ID}"
 EOF

--- a/scripts/export-mongocli-config.py
+++ b/scripts/export-mongocli-config.py
@@ -15,6 +15,6 @@ else:
 if not profile in t:
     raise Exception(f"No profile '{profile}' found in {config}")
 d=t[profile]
-print(f"export ATLAS_PUBLIC_KEY={d['public_api_key']}")
-print(f"export ATLAS_PRIVATE_KEY={d['private_api_key']}")
-print(f"export ATLAS_ORG_ID={d['org_id']}")
+print(f"export MONGODB_ATLAS_PUBLIC_KEY={d['public_api_key']}")
+print(f"export MONGODB_ATLAS_PRIVATE_KEY={d['private_api_key']}")
+print(f"export MONGODB_ATLAS_ORG_ID={d['org_id']}")

--- a/scripts/launch-new-quickstart.sh
+++ b/scripts/launch-new-quickstart.sh
@@ -3,7 +3,7 @@ STACK_NAME="${1:-aws-quickstart}"
 aws cloudformation create-stack \
   --capabilities CAPABILITY_IAM --disable-rollback \
   --template-body file://templates/mongodb-atlas.template.yaml \
-  --parameters ParameterKey=PublicKey,ParameterValue=${ATLAS_PUBLIC_KEY} \
-               ParameterKey=PrivateKey,ParameterValue=${ATLAS_PRIVATE_KEY} \
-               ParameterKey=OrgId,ParameterValue=${ATLAS_ORG_ID} \
+  --parameters ParameterKey=PublicKey,ParameterValue=${MONGODB_ATLAS_PUBLIC_KEY} \
+               ParameterKey=PrivateKey,ParameterValue=${MONGODB_ATLAS_PRIVATE_KEY} \
+               ParameterKey=OrgId,ParameterValue=${MONGODB_ATLAS_ORG_ID} \
   --stack-name "${STACK_NAME}"

--- a/scripts/launch-x-quickstart.sh
+++ b/scripts/launch-x-quickstart.sh
@@ -8,8 +8,8 @@ echo "EXTRA_PARAMS=${EXTRA_PARAMS}"
 aws cloudformation create-stack \
   --capabilities CAPABILITY_IAM --disable-rollback \
   --template-body "file://${TEMPLATE}" \
-  --parameters ParameterKey=PublicKey,ParameterValue=${ATLAS_PUBLIC_KEY} \
-               ParameterKey=PrivateKey,ParameterValue=${ATLAS_PRIVATE_KEY} \
-               ParameterKey=OrgId,ParameterValue=${ATLAS_ORG_ID} \
+  --parameters ParameterKey=PublicKey,ParameterValue=${MONGODB_ATLAS_PUBLIC_KEY} \
+               ParameterKey=PrivateKey,ParameterValue=${MONGODB_ATLAS_PRIVATE_KEY} \
+               ParameterKey=OrgId,ParameterValue=${MONGODB_ATLAS_ORG_ID} \
                ${EXTRA_PARAMS} \
   --stack-name "${STACK_NAME}"


### PR DESCRIPTION
*Issue #, if available:*
similar changes in: https://github.com/mongodb/mongodbatlas-cloudformation-resources/pull/785

*Description of changes:*
This updates the use of MongoDB environment variables to the preferred names so it's more consistent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
